### PR TITLE
Add inverted print option

### DIFF
--- a/lua/cfc_dynamic_limits/cl_chat.lua
+++ b/lua/cfc_dynamic_limits/cl_chat.lua
@@ -1,5 +1,7 @@
 local prefixColor = Color( 41, 41, 41 )
 local textColor = Color( 180, 180, 180 )
+local enableColor = Color( 0, 255, 0 )
+local disableColor = Color( 255, 0, 0 )
 local prefix = "• Dynamic Limits "
 
 net.Receive( "cfc_dynamiclimits_notify", function()
@@ -17,9 +19,9 @@ net.Receive( "cfc_dynamiclimits_notify", function()
     end
 
     if printEnable then
-        chat.AddText( prefixColor, prefix, Color( 0, 255, 0 ), moduleName, textColor, " has been enabled." )
+        chat.AddText( prefixColor, prefix, enableColor, moduleName, textColor, " has been enabled." )
     else
-        chat.AddText( prefixColor, prefix, Color( 255, 0, 0 ), moduleName, textColor, " has been disabled." )
+        chat.AddText( prefixColor, prefix, disableColor, moduleName, textColor, " has been disabled." )
     end
 end )
 

--- a/lua/cfc_dynamic_limits/cl_chat.lua
+++ b/lua/cfc_dynamic_limits/cl_chat.lua
@@ -9,12 +9,15 @@ net.Receive( "cfc_dynamiclimits_notify", function()
     if not mod then return end
 
     local enable = net.ReadBool()
+    mod.enabled = enable
+
+    if mod.invertedPrint then
+        enable = not enable
+    end
 
     if enable then
-        mod.enabled = true
         chat.AddText( prefixColor, prefix, Color( 0, 255, 0 ), moduleName, textColor, " has been enabled." )
     else
-        mod.enabled = false
         chat.AddText( prefixColor, prefix, Color( 255, 0, 0 ), moduleName, textColor, " has been disabled." )
     end
 end )

--- a/lua/cfc_dynamic_limits/cl_chat.lua
+++ b/lua/cfc_dynamic_limits/cl_chat.lua
@@ -11,11 +11,12 @@ net.Receive( "cfc_dynamiclimits_notify", function()
     local enable = net.ReadBool()
     mod.enabled = enable
 
+    local printEnable = enable
     if mod.invertedPrint then
-        enable = not enable
+        printEnable = not enable
     end
 
-    if enable then
+    if printEnable then
         chat.AddText( prefixColor, prefix, Color( 0, 255, 0 ), moduleName, textColor, " has been enabled." )
     else
         chat.AddText( prefixColor, prefix, Color( 255, 0, 0 ), moduleName, textColor, " has been disabled." )

--- a/lua/cfc_dynamic_limits/modules/acf_surprise.lua
+++ b/lua/cfc_dynamic_limits/modules/acf_surprise.lua
@@ -1,4 +1,4 @@
-local threshold = 25
+local threshold = 2
 local thresholdType = "number"
 local description = {
     "At 25 players, ACF weapons are disabled"
@@ -16,4 +16,4 @@ local function off()
     end
 end
 
-CFCDynamicLimits.Action( "Disable ACF", on, off, threshold, description, thresholdType )
+CFCDynamicLimits.Action( "ACF", on, off, threshold, description, thresholdType, true )

--- a/lua/cfc_dynamic_limits/modules/acf_surprise.lua
+++ b/lua/cfc_dynamic_limits/modules/acf_surprise.lua
@@ -1,4 +1,4 @@
-local threshold = 2
+local threshold = 25
 local thresholdType = "number"
 local description = {
     "At 25 players, ACF weapons are disabled"

--- a/lua/cfc_dynamic_limits/sh_modules.lua
+++ b/lua/cfc_dynamic_limits/sh_modules.lua
@@ -1,4 +1,4 @@
-function CFCDynamicLimits.Action( name, onFunc, offFunc, threshold, descriptionTbl, thresholdType )
+function CFCDynamicLimits.Action( name, onFunc, offFunc, threshold, descriptionTbl, thresholdType, invertedPrint )
     if threshold <= 0 then
         error( "threshold must be greater than 0" )
     end
@@ -7,10 +7,13 @@ function CFCDynamicLimits.Action( name, onFunc, offFunc, threshold, descriptionT
         threshold = math.Round( threshold / 100 * game.MaxPlayers() )
     end
 
+    invertedPrint = invertedPrint or false
+
     if SERVER then
         local mod = {
             name = name,
             threshold = threshold,
+            invertedPrint = invertedPrint,
             enabled = false
         }
 
@@ -32,7 +35,8 @@ function CFCDynamicLimits.Action( name, onFunc, offFunc, threshold, descriptionT
             name = name,
             threshold = threshold,
             description = descriptionTbl,
-            enabled = player.GetCount() >= threshold
+            invertedPrint = invertedPrint,
+            enabled = player.GetCount() >= threshold,
         }
     end
 end


### PR DESCRIPTION
In the case we disable a specific addon or feature it's useful to invert the prints to format the prints better.

## Example:
Before:
![image](https://github.com/CFC-Servers/cfc_dynamic_limits/assets/69946827/49505409-ecb7-4fa0-af0b-3af4c0984a4f)

After:
![image](https://github.com/CFC-Servers/cfc_dynamic_limits/assets/69946827/c91cf208-20c7-4988-aae9-c8a8df3fd1c5)
